### PR TITLE
dependent version of consolidate.js is updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "co-render",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": "visionmedia/co-render",
   "description": "Thunk-based template rendering for Co and others",
   "keywords": [
@@ -10,7 +10,7 @@
     "engine"
   ],
   "dependencies": {
-    "consolidate": "~0.9.1",
+    "consolidate": "~0.10.0",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
I know that there is an existing PR to do the same, but this commit also changes the package.json's version. This will be needed to update co-view too. I wish I could use Nunjucks in Koa applications